### PR TITLE
fix: use collections.abc Set

### DIFF
--- a/src/python_hiccup/transform/core.py
+++ b/src/python_hiccup/transform/core.py
@@ -2,9 +2,10 @@
 
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
 from functools import reduce
 
-Item = str | set | Mapping | Sequence
+Item = str | AbstractSet | Mapping | Sequence
 
 ATTRIBUTES = "attributes"
 BOOLEAN_ATTRIBUTES = "boolean_attributes"


### PR DESCRIPTION
A small change to go almost "all in" the `collections.abc` typings.