### PR TITLE
fix(script tag): explicit closing tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-hiccup"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -71,8 +71,11 @@ def _to_html(tag: Mapping) -> list:
 
     begin = f"{element}{element_attributes}" if element_attributes else element
 
-    if flattened or content or _closing_tag(element):
+    if flattened or content:
         return [f"<{begin}>", *flattened, *content, f"</{element}>"]
+
+    if _closing_tag(element):
+        return [f"<{begin}>", f"</{element}>"]
 
     extra = _suffix(begin)
 

--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -43,6 +43,12 @@ def _to_bool_attributes(acc: str, attributes: set) -> str:
     return _join(acc, attrs)
 
 
+def _closing_tag(element: str) -> bool:
+    specials = {"script"}
+
+    return str.lower(element) in specials
+
+
 def _suffix(element_data: str) -> str:
     specials = {"doctype"}
     normalized = str.lower(element_data)
@@ -65,7 +71,7 @@ def _to_html(tag: Mapping) -> list:
 
     begin = f"{element}{element_attributes}" if element_attributes else element
 
-    if flattened or content:
+    if flattened or content or _closing_tag(element):
         return [f"<{begin}>", *flattened, *content, f"</{element}>"]
 
     extra = _suffix(begin)

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -41,11 +41,20 @@ def test_parses_attribute_shorthand() -> None:
     assert render(data) == expected
 
 
+def test_explicit_closing_tag() -> None:
+    """Assert that some html elements are parsed with a closing tag."""
+    data = ["script"]
+
+    expected = "<script></script>"
+
+    assert render(data) == expected
+
+
 def test_parses_boolean_attributes() -> None:
     """Assert that attributes without values, such as async or defer, is parsed as expected."""
     data = ["script", {"async"}, {"src": "path/to/script"}]
 
-    expected = '<script src="path/to/script" async />'
+    expected = '<script src="path/to/script" async></script>'
 
     assert render(data) == expected
 

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "python-hiccup"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
the `<script>` tag needs a closing tag (`</script>`), otherwise the HTML will not be rendered correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing an issue with rendering HTML.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-hiccup/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-hiccup/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
