### PR TITLE
fix(content): allow defining inner content without any wrapping html tags, with the ordering kept as written in hiccup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Python Hiccup
 
-This project started out as a fun challenge, and now evolving into something that could be useful.
-
-Current status: _experimental_
+Python Hiccup is a library for representing HTML using plain Python data structures.
 
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/DavidVujic/python-hiccup/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/DavidVujic/python-hiccup/tree/main)
 
@@ -13,6 +11,8 @@ Current status: _experimental_
 ## What is Python Hiccup?
 This is a Python implementation of the Hiccup syntax. Python Hiccup is a library for representing HTML in Python.
 Using `list` or `tuple` to represent HTML elements, and `dict` to represent the element attributes.
+
+_This project started out as a fun coding challenge, and now evolving into something useful for Python Dev teams._
 
 ## Usage
 Create server side HTML using plain Python data structures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "python-hiccup"
-version = "0.2.0"
-description = "Add your description here"
+version = "0.3.0"
+description = "Python Hiccup is a library for representing HTML using plain Python data structures"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = []

--- a/src/python_hiccup/transform/__init__.py
+++ b/src/python_hiccup/transform/__init__.py
@@ -1,5 +1,5 @@
 """Transform Hiccup syntax."""
 
-from python_hiccup.transform.core import transform
+from python_hiccup.transform.core import CONTENT_TAG, transform
 
-__all__ = ["transform"]
+__all__ = ["CONTENT_TAG", "transform"]

--- a/src/python_hiccup/transform/core.py
+++ b/src/python_hiccup/transform/core.py
@@ -10,7 +10,8 @@ Item = str | AbstractSet | Mapping | Sequence
 ATTRIBUTES = "attributes"
 BOOLEAN_ATTRIBUTES = "boolean_attributes"
 CHILDREN = "children"
-CONTENT = "content"
+
+CONTENT_TAG = "<::HICCUP_CONTENT::>"
 
 
 def _is_attribute(item: Item) -> bool:
@@ -25,12 +26,6 @@ def _is_child(item: Item) -> bool:
     return isinstance(item, list | tuple)
 
 
-def _is_content(item: Item) -> bool:
-    pipeline = [_is_attribute, _is_boolean_attribute, _is_child]
-
-    return not any(fn(item) for fn in pipeline)
-
-
 def _is_sibling(item: Item) -> bool:
     return _is_child(item)
 
@@ -40,8 +35,6 @@ def _key_for_group(item: Item) -> str:
         return ATTRIBUTES
     if _is_boolean_attribute(item):
         return BOOLEAN_ATTRIBUTES
-    if _is_content(item):
-        return CONTENT
 
     return CHILDREN
 
@@ -67,6 +60,9 @@ def _extract_from_tag(tag: str) -> tuple[str, dict]:
 
 
 def _transform_tags(tags: Sequence) -> dict:
+    if not isinstance(tags, list | tuple):
+        return {CONTENT_TAG: tags}
+
     first, *rest = tags
 
     element, extracted = _extract_from_tag(first)

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -132,9 +132,9 @@ def test_generates_an_element_with_children() -> None:
 
 def test_allows_numeric_values_in_content() -> None:
     """Assert that numeric values are allowed as the content of an element."""
-    data = ["ul", ["li", 1]]
+    data = ["ul", ["li", 1], ["li", 2.2]]
 
-    assert render(data) == "<ul><li>1</li></ul>"
+    assert render(data) == "<ul><li>1</li><li>2.2</li></ul>"
 
 
 def test_order_of_items() -> None:

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -135,3 +135,10 @@ def test_allows_numeric_values_in_content() -> None:
     data = ["ul", ["li", 1]]
 
     assert render(data) == "<ul><li>1</li></ul>"
+
+
+def test_order_of_items() -> None:
+    """Assert that items of different types are ordered as expected."""
+    data = ["h1", "some ", ["span.pys", "<py>"]]
+
+    assert render(data) == '<h1>some <span class="pys">&lt;py&gt;</span></h1>'

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "python-hiccup"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow adding content (i.e. inner text) to HTML elements, without having to wrap it within a HTML tag.

Example:
```python
["div", "hello world", ["ul", ["li", "one"], ["li", "two"]]]
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #7 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-hiccup/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-hiccup/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
