### PR TITLE
feat: mimicks dangerouslySetInnerHTML behavior

### DIFF
--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -4,8 +4,17 @@ import html
 import operator
 from collections.abc import Mapping, Sequence
 from functools import reduce
+from itertools import filterfalse as reject
 
-from python_hiccup.transform import CONTENT_TAG, transform
+from python_hiccup.transform import CONTENT_TAG, HTML_SETTER, transform
+
+
+def _has_setter(container: dict | list) -> bool:
+    return operator.contains(container, HTML_SETTER)
+
+
+def _has_content(container: dict | list) -> bool:
+    return operator.contains(container, CONTENT_TAG)
 
 
 def _element_allows_raw_content(element: str) -> bool:
@@ -32,7 +41,7 @@ def _join(acc: str, attrs: Sequence) -> str:
 
 
 def _to_attributes(acc: str, attributes: Mapping) -> str:
-    attrs = [f'{k}="{v}"' for k, v in attributes.items()]
+    attrs = [f'{k}="{v}"' for k, v in attributes.items() if k != HTML_SETTER]
 
     return _join(acc, attrs)
 
@@ -60,12 +69,34 @@ def _is_content(element: str) -> bool:
     return element == CONTENT_TAG
 
 
-def _to_html(tag: Mapping, parent: str = "") -> list:
+def _to_html(tag: Mapping, parent: str = "", rename: str | None = None) -> list:
     element = next(iter(tag.keys()))
     child = next(iter(tag.values()))
 
+    html_setter = next(filter(_has_setter, tag.get("attributes", [])), None)
+
+    if html_setter is not None:
+        return "".join(
+            _to_html(
+                {
+                    "script": [
+                        *reject(_has_content, tag[element]),
+                        {CONTENT_TAG: html_setter[HTML_SETTER].get("__html", "")},
+                    ],
+                    "attributes": [
+                        *reject(_has_setter, tag["attributes"]),
+                        dict(reject(_has_setter, html_setter.items())),
+                    ],
+                },
+                parent,
+                rename=element,
+            )
+        )
+
     if _is_content(element):
         return [_escape(str(child), parent)]
+
+    tag_name = rename or element
 
     attributes = reduce(_to_attributes, tag.get("attributes", []), "")
     bool_attributes = reduce(_to_bool_attributes, tag.get("boolean_attributes", []), "")
@@ -74,13 +105,13 @@ def _to_html(tag: Mapping, parent: str = "") -> list:
     matrix = [_to_html(c, element) for c in child]
     flattened: list = reduce(operator.iadd, matrix, [])
 
-    begin = f"{element}{element_attributes}" if element_attributes else element
+    begin = f"{tag_name}{element_attributes}" if element_attributes else tag_name
 
     if flattened:
-        return [f"<{begin}>", *flattened, f"</{element}>"]
+        return [f"<{begin}>", *flattened, f"</{tag_name}>"]
 
-    if _closing_tag(element):
-        return [f"<{begin}>", f"</{element}>"]
+    if _closing_tag(tag_name):
+        return [f"<{begin}>", f"</{tag_name}>"]
 
     extra = _suffix(begin)
 

--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -76,22 +76,24 @@ def _to_html(tag: Mapping, parent: str = "", rename: str | None = None) -> list:
     html_setter = next(filter(_has_setter, tag.get("attributes", [])), None)
 
     if html_setter is not None:
-        return "".join(
-            _to_html(
-                {
-                    "script": [
-                        *reject(_has_content, tag[element]),
-                        {CONTENT_TAG: html_setter[HTML_SETTER].get("__html", "")},
-                    ],
-                    "attributes": [
-                        *reject(_has_setter, tag["attributes"]),
-                        dict(reject(_has_setter, html_setter.items())),
-                    ],
-                },
-                parent,
-                rename=element,
+        return [
+            "".join(
+                _to_html(
+                    {
+                        "script": [
+                            *reject(_has_content, tag[element]),
+                            {CONTENT_TAG: html_setter[HTML_SETTER].get("__html", "")},
+                        ],
+                        "attributes": [
+                            *reject(_has_setter, tag["attributes"]),
+                            dict(reject(_has_setter, html_setter.items())),
+                        ],
+                    },
+                    parent,
+                    rename=element,
+                )
             )
-        )
+        ]
 
     if _is_content(element):
         return [_escape(str(child), parent)]

--- a/src/python_hiccup/transform/__init__.py
+++ b/src/python_hiccup/transform/__init__.py
@@ -1,5 +1,5 @@
 """Transform Hiccup syntax."""
 
-from python_hiccup.transform.core import CONTENT_TAG, transform
+from python_hiccup.transform.core import CONTENT_TAG, HTML_SETTER, transform
 
-__all__ = ["CONTENT_TAG", "transform"]
+__all__ = ["CONTENT_TAG", "HTML_SETTER", "transform"]

--- a/src/python_hiccup/transform/core.py
+++ b/src/python_hiccup/transform/core.py
@@ -10,6 +10,7 @@ Item = str | AbstractSet | Mapping | Sequence
 ATTRIBUTES = "attributes"
 BOOLEAN_ATTRIBUTES = "boolean_attributes"
 CHILDREN = "children"
+HTML_SETTER = "dangerouslySetInnerHTML"
 
 CONTENT_TAG = "<::HICCUP_CONTENT::>"
 

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -142,3 +142,27 @@ def test_order_of_items() -> None:
     data = ["h1", "some ", ["span.pys", "<py>"]]
 
     assert render(data) == '<h1>some <span class="pys">&lt;py&gt;</span></h1>'
+
+
+def test_html_entities() -> None:
+    """HTML entities get escaped."""
+    data = ["p", "Go &larr; left or &rarr; right."]
+
+    assert render(data) == "<p>Go &amp;larr; left or &amp;rarr; right.</p>"
+
+
+def test_dangerously_set_inner_html() -> None:
+    """Mimick dangerouslySetInnerHTML behavior."""
+    data = [
+        "div",
+        [
+            "a",
+            {
+                "href": "/location",
+                "dangerouslySetInnerHTML": {"__html": "Location &rarr;"},
+            },
+            "Location",
+        ],
+    ]
+
+    assert render(data) != '<div><a href="/location">Location &amp;rarr;</a></div>'


### PR DESCRIPTION
Implementation of dangerouslySetInnerHTML attribute just like in React https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html

## Description
Allows one to pass raw HTML strings to an element, overriding the HTML escaping routine:

```python
data = [
    "div",
    [
        "a",
        {
            "href": "/location",
            "dangerouslySetInnerHTML": {"__html": "Location &rarr;"},
        },
        "Location",
    ],
]

assert render(data) != '<div><a href="/location">Location &amp;rarr;</a></div>'
```

## Motivation and Context
This is useful to - for example - render content of an SVG with hiccup, or HTML entities like &copy; (`&copy;`) as another example.

~~Although I did check that changing  the `_escape` function to do `html.unescape(html.escape("&copy; Python Hiccup 2025"))` can accomplish the same. I can include it in this PR if it's wanted.~~ (edit: ignore this, bad idea)

The way it's implemented is by adding a nullable string parameter to `_to_html` called `rename` which, when set, renames the HTML element about to get rendered. By doing this we can detect the `setDangerouslyInnerHTML` attribute and early return a recursive re-render of a new version of the element but pretending it's a `<style>` or `<script>` tag - both of which aren't supposed to get escaped per-spec - and renaming it back to its original name.

## How Has This Been Tested?

Unit tests and with an SVG: 

![Screenshot_2025-09-06_08-54-41](https://github.com/user-attachments/assets/c419a933-ad4a-410c-a780-83334bcc1541)

It might prove beneficial to stress test it, I do write a lot of Python with FP and try hard to avoid bottlenecks however I might've missed something.

Perhaps a switch to comparing strings to detect usage of `dangerouslySetInnerHTML` might improve performance over filtering the attributes of every element in the tree.

Also I'm aware the sizable change in `_to_html` might somehow fit better elsewhere but I'm not yet sure where.

## Types of changes
- [ ?] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x ] I have read the [code of conduct](https://github.com/davidvujic/python-hiccup/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-hiccup/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).

Should I also mention something in the docs? Is it significant enough?