### PR TITLE
feat(inner content): allow passing content as a function, as a custom parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ The HTML equivalent is:
 <script async src="js/script.js"></script>
 ```
 
+### Adding unescaped content
+This is useful when rendering HTML entities like `&copy;`.
+
+``` python
+from python_hiccup.html import raw
+
+data = ["div", raw("&copy; this should <strong>not</strong> be escaped!")]
+```
+
+The HTML output:
+
+``` html
+<div>&copy; this should <strong>not</strong> be escaped!</div>
+```
+
 ## Resources
 - [PyScript and python-hiccup example](https://pyscript.com/@davidvujic/pyscript-jokes-with-a-hiccup/latest?files=main.py) - PyScript Jokes with a Hiccup
 - [Hiccup](https://github.com/weavejester/hiccup) - the original implementation, for Clojure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-hiccup"
-version = "0.3.4"
+version = "0.4.0"
 description = "Python Hiccup is a library for representing HTML using plain Python data structures"
 authors = [{name = "David Vujic"}]
 readme = "README.md"

--- a/src/python_hiccup/html/__init__.py
+++ b/src/python_hiccup/html/__init__.py
@@ -1,5 +1,5 @@
 """Render data into HTML."""
 
-from python_hiccup.html.core import render
+from python_hiccup.html.core import raw, render
 
-__all__ = ["render"]
+__all__ = ["raw", "render"]

--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -65,7 +65,7 @@ def _to_html(tag: Mapping, parent: str = "") -> list:
     child = next(iter(tag.values()))
 
     if _is_content(element):
-        return [_escape(str(child), parent)]
+        return child() if callable(child) else [_escape(str(child), parent)]
 
     attributes = reduce(_to_attributes, tag.get("attributes", []), "")
     bool_attributes = reduce(_to_bool_attributes, tag.get("boolean_attributes", []), "")

--- a/src/python_hiccup/html/core.py
+++ b/src/python_hiccup/html/core.py
@@ -2,7 +2,7 @@
 
 import html
 import operator
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from functools import reduce
 
 from python_hiccup.transform import CONTENT_TAG, transform
@@ -60,12 +60,16 @@ def _is_content(element: str) -> bool:
     return element == CONTENT_TAG
 
 
+def _is_raw(content: str | Callable) -> bool:
+    return callable(content) and content.__name__ == "raw_content"
+
+
 def _to_html(tag: Mapping, parent: str = "") -> list:
     element = next(iter(tag.keys()))
     child = next(iter(tag.values()))
 
     if _is_content(element):
-        return child() if callable(child) else [_escape(str(child), parent)]
+        return child() if _is_raw(child) else [_escape(str(child), parent)]
 
     attributes = reduce(_to_attributes, tag.get("attributes", []), "")
     bool_attributes = reduce(_to_bool_attributes, tag.get("boolean_attributes", []), "")
@@ -96,3 +100,12 @@ def render(data: Sequence) -> str:
     transformed_html: list = reduce(operator.iadd, matrix, [])
 
     return "".join(transformed_html)
+
+
+def raw(content: str | float) -> Callable:
+    """Content that should not be escaped when rendering HTML elements."""
+
+    def raw_content() -> str | float:
+        return content
+
+    return raw_content

--- a/src/python_hiccup/transform/core.py
+++ b/src/python_hiccup/transform/core.py
@@ -1,11 +1,11 @@
 """Transform a sequence of tag data into groups."""
 
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from collections.abc import Set as AbstractSet
 from functools import reduce
 
-Item = str | AbstractSet | Mapping | Sequence
+Item = str | AbstractSet | Mapping | Sequence | Callable
 
 ATTRIBUTES = "attributes"
 BOOLEAN_ATTRIBUTES = "boolean_attributes"

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -142,3 +142,10 @@ def test_order_of_items() -> None:
     data = ["h1", "some ", ["span.pys", "<py>"]]
 
     assert render(data) == '<h1>some <span class="pys">&lt;py&gt;</span></h1>'
+
+
+def test_content_as_function() -> None:
+    """Allow defining content as a callable function, as a custom parser."""
+    data = ["div", lambda: "&copy;"]
+
+    assert render(data) == "<div>&copy;</div>"

--- a/test/test_render_html.py
+++ b/test/test_render_html.py
@@ -1,6 +1,6 @@
 """Unit tests for the python_hiccup.html.render function."""
 
-from python_hiccup.html import render
+from python_hiccup.html import raw, render
 
 
 def test_returns_a_string() -> None:
@@ -146,6 +146,7 @@ def test_order_of_items() -> None:
 
 def test_content_as_function() -> None:
     """Allow defining content as a callable function, as a custom parser."""
-    data = ["div", lambda: "&copy;"]
+    content = "&copy; this <strong>should</strong> not be escaped!"
 
-    assert render(data) == "<div>&copy;</div>"
+    assert render(["div", raw("&copy;")]) == "<div>&copy;</div>"
+    assert render(["div", raw(content)]) == f"<div>{content}</div>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To allow passing in _inner html_ as a string, without escaping the content.

Example: adding  `&copy;` as inner html, it is now possible to pass the content as a function (or a custom render function for that particular content).

```python
from python_hiccup.html import raw

data = ["div", raw("&copy; this should <strong>not</strong> be escaped!")]
```

the rendered output:
```html
<div>&copy; this should <strong>not</strong> be escaped!</div>
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Idea and feature request coming from #12 ⭐ 

This Pull Request is an alternative to the proposed solution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/python-hiccup/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/python-hiccup/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
